### PR TITLE
Coherent Image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-   * docker run -it --rm --link leader -v $(JAR_LOCATION):/jars:ro -v $(RASTER_LOCATION):/rasters:ro geowaveclient:0
+   * docker run -it --rm --net=geowave -v $HOME/Pictures/tif:/rasters:ro -v $(pwd)/raster/target/scala-2.11:/jars:ro java:openjdk-8u72-jdk
    * java -cp /jars/ingest-vector-assembly-0.jar com.example.ingest.vector.SimpleIngestIndexWriter leader instance root password gwVector
-   * java -cp /jars/ingest-raster-assembly-0.jar com.example.ingest.raster.RasterIngest leader instance root password gwRaster /rasters/raster.tiff
-
-   * globalVisibility = context.getConfiguration().get(AbstractMapReduceIngest.GLOBAL_VISIBILITY_KEY);
-   * primaryIndexIds = AbstractMapReduceIngest.getPrimaryIndexIds(context.getConfiguration());
+   * java -cp /jars/ingest-raster-assembly-0.jar com.example.ingest.raster.RasterIngest leader instance root password gwRaster /rasters/Globe15_TIFF.tif

--- a/raster/RasterIngest.scala
+++ b/raster/RasterIngest.scala
@@ -21,7 +21,7 @@ object RasterIngest {
   val log = Logger.getLogger(RasterIngest.getClass)
 
   val policy = AbstractGridFormat.OVERVIEW_POLICY.createValue; policy.setValue(OverviewPolicy.IGNORE)
-  val gridSize = AbstractGridFormat.SUGGESTED_TILE_SIZE.createValue; gridSize.setValue("256,256")
+  val gridSize = AbstractGridFormat.SUGGESTED_TILE_SIZE.createValue; gridSize.setValue("512,512")
   val useJaiRead = AbstractGridFormat.USE_JAI_IMAGEREAD.createValue; useJaiRead.setValue(true)
 
   def getAccumuloOperationsInstance(
@@ -72,7 +72,7 @@ object RasterIngest {
     val dataStore = getGeowaveDataStore(basicOperations)
     val index = createSpatialIndex
     // https://ngageoint.github.io/geowave/apidocs/mil/nga/giat/geowave/adapter/raster/adapter/RasterDataAdapter.html
-    val adapter = new RasterDataAdapter(coverageName, metadata, image, 256, false)
+    val adapter = new RasterDataAdapter(coverageName, metadata, image, 256, true)
 
     val indexWriter = dataStore.createWriter(adapter, index).asInstanceOf[IndexWriter[GridCoverage]]
 


### PR DESCRIPTION
This code was able to produce a coherent image.

The container was invoked like this:

```
docker run -it --rm --net=geowave -v $HOME/Pictures/tif:/rasters:ro -v $(pwd)/raster/target/scala-2.11:/jars:ro java:openjdk-8u72-jdk
```

and the ingest was done like this:

```
java -cp /jars/ingest-raster-assembly-0.jar com.example.ingest.raster.RasterIngest leader instance root password gwRaster /rasters/Globe15_TIFF.tif
```
